### PR TITLE
Fix test failure caused by differing output order.

### DIFF
--- a/boundaries/tests/test_boundary_list_filter.py
+++ b/boundaries/tests/test_boundary_list_filter.py
@@ -67,7 +67,7 @@ class BoundaryListFilterTestCase(ViewTestCase):
     def test_filter_intersects(self):
         response = self.client.get(self.url, {'intersects': 'abc/bar'})
         self.assertResponse(response)
-        self.assertJSONEqual(response, '{"meta": {"total_count": 2, "related": {"centroids_url": "/boundaries/centroid?intersects=abc%2Fbar", "simple_shapes_url": "/boundaries/simple_shape?intersects=abc%2Fbar", "shapes_url": "/boundaries/shape?intersects=abc%2Fbar"}, "next": null, "limit": 20, "offset": 0, "previous": null}, "objects": [{"url": "/boundaries/inc/foo/", "boundary_set_name": "", "external_id": "1", "name": "Foo", "related": {"boundary_set_url": "/boundary-sets/inc/"}}, {"url": "/boundaries/abc/bar/", "boundary_set_name": "", "external_id": "2", "name": "Bar", "related": {"boundary_set_url": "/boundary-sets/abc/"}}]}')
+        self.assertJSONEqual(response, '{"meta": {"total_count": 2, "related": {"centroids_url": "/boundaries/centroid?intersects=abc%2Fbar", "simple_shapes_url": "/boundaries/simple_shape?intersects=abc%2Fbar", "shapes_url": "/boundaries/shape?intersects=abc%2Fbar"}, "next": null, "limit": 20, "offset": 0, "previous": null}, "objects": [{"url": "/boundaries/abc/bar/", "boundary_set_name": "", "external_id": "2", "name": "Bar", "related": {"boundary_set_url": "/boundary-sets/abc/"}}, {"url": "/boundaries/inc/foo/", "boundary_set_name": "", "external_id": "1", "name": "Foo", "related": {"boundary_set_url": "/boundary-sets/inc/"}}]}')
 
     def test_filter_intersects_404(self):
         response = self.client.get(self.url, {'intersects': 'inc/nonexistent'})

--- a/boundaries/tests/test_boundary_list_geo_filter.py
+++ b/boundaries/tests/test_boundary_list_geo_filter.py
@@ -65,7 +65,7 @@ class BoundaryListGeoFilterTestCase(ViewTestCase):
     def test_filter_intersects(self):
         response = self.client.get(self.url, {'intersects': 'abc/bar'})
         self.assertResponse(response)
-        self.assertJSONEqual(response, '{"objects": [{"shape": {"type": "MultiPolygon", "coordinates": [[[[0.0, 0.0], [0.0, 5.0], [5.0, 5.0], [0.0, 0.0]]]]}, "name": "Foo"}, {"shape": {"type": "MultiPolygon", "coordinates": [[[[1.0, 2.0], [1.0, 4.0], [3.0, 4.0], [1.0, 2.0]]]]}, "name": "Bar"}]}')
+        self.assertJSONEqual(response, '{"objects": [{"shape": {"type": "MultiPolygon", "coordinates": [[[[1.0, 2.0], [1.0, 4.0], [3.0, 4.0], [1.0, 2.0]]]]}, "name": "Bar"}, {"shape": {"type": "MultiPolygon", "coordinates": [[[[0.0, 0.0], [0.0, 5.0], [5.0, 5.0], [0.0, 0.0]]]]}, "name": "Foo"}]}')
 
     def test_filter_intersects_404(self):
         response = self.client.get(self.url, {'intersects': 'inc/nonexistent'})

--- a/boundaries/views.py
+++ b/boundaries/views.py
@@ -53,7 +53,7 @@ class BoundaryListView(ModelGeoListView):
                 raise Http404
             except ValueError:
                 raise BadRequest(_("Invalid value for intersects filter"))
-            qs = qs.filter(models.Q(shape__covers=shape) | models.Q(shape__overlaps=shape))
+            qs = qs.filter(models.Q(shape__covers=shape) | models.Q(shape__overlaps=shape)).order_by('name')
 
         if 'touches' in request.GET:
             try:


### PR DESCRIPTION
This is probably not the right way to go about this; the lack of any ordering on Boundary meant that locally some intersect tests failed due to the ordering of the list being different in the test JSON. So I added ordering to the intersect call (and ordering the JSON) which fixed those failing tests, I don't know if it would be better done by default ordering on Boundary itself.
