### PR TITLE
Add start_date and end_date fields to Boundary objects

### DIFF
--- a/boundaries/migrations/0003_auto_20150528_1338.py
+++ b/boundaries/migrations/0003_auto_20150528_1338.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('boundaries', '0002_auto_20141129_1402'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='boundary',
+            name='end_date',
+            field=models.DateField(help_text='The date until which the boundary is in effect.', blank=True, null=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='boundary',
+            name='start_date',
+            field=models.DateField(help_text='The date from which the boundary is in effect.', blank=True, null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/boundaries/models.py
+++ b/boundaries/models.py
@@ -151,8 +151,12 @@ class Boundary(models.Model):
         help_text=ugettext_lazy('The bounding box of the boundary as a list like [xmin, ymin, xmax, ymax] in EPSG:4326.'))
     label_point = models.PointField(blank=True, null=True, spatial_index=False,
         help_text=ugettext_lazy('The point at which to place a label for the boundary in EPSG:4326, used by represent-maps.'))
+    start_date = models.DateField(blank=True, null=True,
+        help_text=ugettext_lazy("The date from which the boundary is in effect."))
+    end_date = models.DateField(blank=True, null=True,
+        help_text=ugettext_lazy("The date until which the boundary is in effect."))
 
-    api_fields = ['boundary_set_name', 'name', 'metadata', 'external_id', 'extent', 'centroid']
+    api_fields = ['boundary_set_name', 'name', 'metadata', 'external_id', 'extent', 'centroid', 'start_date', 'end_date']
     api_fields_doc_from = {'boundary_set_name': 'set_name'}
 
     objects = models.GeoManager()
@@ -320,12 +324,14 @@ slug_re = re.compile(r'[–—]')  # n-dash, m-dash
 class Feature(object):
 
     # @see https://github.com/django/django/blob/master/django/contrib/gis/gdal/feature.py
-    def __init__(self, feature, definition, srs=None, boundary_set=None):
+    def __init__(self, feature, definition, srs=None, boundary_set=None, start_date=None, end_date=None):
         srs = srs or SpatialReference(4326)
         self.feature = feature
         self.definition = definition
         self.geometry = Geometry(feature.geom).transform(srs)
         self.boundary_set = boundary_set
+        self.start_date = start_date
+        self.end_date = end_date
 
     def __str__(self):
         return self.name
@@ -388,6 +394,8 @@ class Feature(object):
             centroid=self.geometry.centroid,
             extent=self.geometry.extent,
             label_point=self.label_point,
+            start_date=self.start_date,
+            end_date=self.end_date,
         )
 
 

--- a/boundaries/tests/test_boundary.py
+++ b/boundaries/tests/test_boundary.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from __future__ import unicode_literals
+import datetime
 
 from django.test import TestCase
 from django.contrib.gis.gdal import OGRGeometry
@@ -61,6 +62,8 @@ class BoundaryTestCase(TestCase):
             external_id=1,
             extent=[0, 0, 1, 1],
             centroid=Point(0, 1),
+            start_date=datetime.date(2000, 1, 1),
+            end_date=datetime.date(2010, 1, 1),
         ).as_dict(), {
             'related': {
                 'boundary_set_url': '/boundary-sets/foo/',
@@ -80,6 +83,8 @@ class BoundaryTestCase(TestCase):
                 'type': 'Point',
                 'coordinates': (0.0, 1.0),
             },
+            'start_date': '2000-01-01',
+            'end_date': '2010-01-01',
         })
 
         self.assertEqual(Boundary(
@@ -99,6 +104,8 @@ class BoundaryTestCase(TestCase):
             'external_id': '',
             'extent': None,
             'centroid': None,
+            'start_date': None,
+            'end_date': None,
         })
 
     def test_prepare_queryset_for_get_dicts(self):

--- a/boundaries/tests/test_boundary_detail.py
+++ b/boundaries/tests/test_boundary_detail.py
@@ -26,6 +26,8 @@ class BoundaryDetailTestCase(ViewTestCase, ViewsTests, PrettyTests):
         'centroid': None,
         'extent': None,
         'external_id': '',
+        'start_date': None,
+        'end_date': None,
         'metadata': {},
     }
 


### PR DESCRIPTION
@paultag and I are looking to have `start_date` and `end_date` at the `Boundary` level (not just the `BoundarySet` level). Use case example: the current official file for state legislative districts is not accurate for Mississippi because that state lagged too much on its post-Census redistricting. Therefore, although the `BoundarySet`'s `start_date` and `end_date` are accurate for almost every `Boundary`, we need a way to special-case certain `Boundary`s.

I did add `start_date` and `end_date` to the `api_fields` for `Boundary`, but I don't believe it's a big problem for us if they're excluded from that list.