### PR TITLE
Raising length on external_id field

### DIFF
--- a/boundaries/migrations/0004_auto_20150921_1607.py
+++ b/boundaries/migrations/0004_auto_20150921_1607.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('boundaries', '0003_auto_20150528_1338'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='boundary',
+            name='external_id',
+            field=models.CharField(max_length=255, help_text='An identifier of the boundary, which should be unique within the set.'),
+        ),
+    ]

--- a/boundaries/models.py
+++ b/boundaries/models.py
@@ -135,7 +135,7 @@ class Boundary(models.Model):
         help_text=ugettext_lazy('A generic singular name for the boundary.'))
     slug = models.SlugField(max_length=200, db_index=True,
         help_text=ugettext_lazy("The boundary's unique identifier within the set, used as a path component in URLs."))
-    external_id = models.CharField(max_length=64,
+    external_id = models.CharField(max_length=255,
         help_text=ugettext_lazy("An identifier of the boundary, which should be unique within the set."))
     name = models.CharField(max_length=192, db_index=True,
         help_text=ugettext_lazy('The name of the boundary.'))


### PR DESCRIPTION
 We're interested in linking things from the represent boundary service over to our imago api. We've got the ocd-division ID showing up in the post listing now over on the imago side and now we're wanting to add it to the represent side. I thought the easiest way of sticking that in there was in the external_id field which is a varchar field limited to 64 characters. This PR raises that limit to 255 and includes the appropriate migration.