### PR TITLE
Fix for static files still being omitted; bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1 (2017-02-23)
+
+* Python packaging change to fix omitting data files when installing
+
 ## 0.9.0 (2017-02-23)
 
 * Use Django 1.9's `JSONField` to migrate to PostgreSQL 9.4's `jsonb` datatype.

--- a/boundaries/management/commands/loadshapefiles.py
+++ b/boundaries/management/commands/loadshapefiles.py
@@ -48,7 +48,7 @@ class Command(BaseCommand):
             help=_('Merge strategy when there are duplicate slugs, either "combine" (extend the MultiPolygon) or "union" (union the geometries).')),
 
     def get_version(self):
-        return '0.9.0'
+        return '0.9.1'
 
     def handle(self, *args, **options):
         if settings.DEBUG:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="represent-boundaries",
-    version="0.9.0",
+    version="0.9.1",
     description="A web API to geographic boundaries loaded from shapefiles, packaged as a Django app.",
     author="Open North Inc.",
     author_email="represent@opennorth.ca",
@@ -10,6 +10,8 @@ setup(
     license="MIT",
     # If packaged as a zip/egg, Django will by default not find static files.
     zip_safe=False,
+    # Tells setuptools to look in MANIFEST.in
+    include_package_data=True,
     packages=[
         'boundaries',
         'boundaries.management',


### PR DESCRIPTION
Apologies for the flood of releases! I'd thought my local tests showed that `zip_safe` on its own fixed the missing-resources bug, but it looks like it needs still more flags (ah, Python packaging). This definitely works locally now, and I have strong hopes that it will still work once pip and PyPI are involved.